### PR TITLE
Blog card grid layout — Casey Nelson style

### DIFF
--- a/_includes/blog-index.njk
+++ b/_includes/blog-index.njk
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    {% include "head.njk" %}
+    <link rel="stylesheet" href="/assets/css/blog.css">
+  </head>
+  <body>
+
+    {% include "header.njk" %}
+    {% include "nav.njk" %}
+
+    <main>
+
+      <!-- Hero -->
+      <div class="blog-hero">
+        <h1>Blog</h1>
+        <p class="blog-subtitle">Tips, updates &amp; insights from the Roof Rite team</p>
+      </div>
+
+      <!-- Search -->
+      <div class="blog-search-wrap">
+        <div class="blog-search-box">
+          <span class="blog-search-icon">&#128269;</span>
+          <input type="text" id="blog-search" placeholder="Search articles…" oninput="filterBlog()">
+        </div>
+      </div>
+
+      <!-- Category filter pills -->
+      <div class="blog-filters">
+        <button class="filter-btn active" onclick="setFilter('all', this)">ALL POSTS</button>
+        <button class="filter-btn" onclick="setFilter('residential', this)">RESIDENTIAL</button>
+        <button class="filter-btn" onclick="setFilter('commercial', this)">COMMERCIAL</button>
+        <button class="filter-btn" onclick="setFilter('insurance', this)">INSURANCE</button>
+        <button class="filter-btn" onclick="setFilter('maintenance', this)">MAINTENANCE</button>
+      </div>
+
+      <!-- Blog card grid — auto-populated from all posts tagged "blogpost" -->
+      <div class="blog-grid" id="blog-grid">
+        {% for post in collections.blogpost | reverse %}
+        <article class="blog-card"
+                 data-category="{{ post.data.category | default('general') }}"
+                 data-title="{{ post.data.title | lower }}">
+          <a href="{{ post.url }}">
+            {% if post.data.hero_image %}
+              <img src="{{ post.data.hero_image }}"
+                   alt="{{ post.data.hero_alt | default(post.data.title) }}"
+                   loading="lazy">
+            {% else %}
+              <div class="blog-card-no-img"></div>
+            {% endif %}
+            <div class="blog-card-body">
+              <span class="blog-date">{{ post.data.display_date }}</span>
+              <h2 class="blog-title">{{ post.data.title }}</h2>
+              {% if post.data.summary %}
+                <p class="blog-summary">{{ post.data.summary }}</p>
+              {% endif %}
+            </div>
+          </a>
+        </article>
+        {% endfor %}
+      </div>
+
+      <p class="blog-no-results" id="blog-no-results" style="display:none;">
+        No articles matched your search.
+      </p>
+
+    </main>
+
+    <link rel="stylesheet" href="{{ '/assets/css/main.css' | fingerprint }}">
+    <script defer src="{{ '/assets/js/gallery.js' | fingerprint }}"></script>
+
+    {% include "footer.njk" %}
+
+    <script>
+      let activeCategory = 'all';
+
+      function setFilter(cat, btn) {
+        activeCategory = cat;
+        document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        filterBlog();
+      }
+
+      function filterBlog() {
+        const query = document.getElementById('blog-search').value.toLowerCase();
+        const cards = document.querySelectorAll('.blog-card');
+        let visible = 0;
+        cards.forEach(card => {
+          const catMatch = activeCategory === 'all' || card.dataset.category === activeCategory;
+          const textMatch = !query || card.dataset.title.includes(query);
+          const show = catMatch && textMatch;
+          card.style.display = show ? '' : 'none';
+          if (show) visible++;
+        });
+        document.getElementById('blog-no-results').style.display = visible === 0 ? '' : 'none';
+      }
+    </script>
+
+  </body>
+</html>

--- a/_includes/blog-index.njk
+++ b/_includes/blog-index.njk
@@ -49,7 +49,6 @@
               <div class="blog-card-no-img"></div>
             {% endif %}
             <div class="blog-card-body">
-              <span class="blog-date">{{ post.data.display_date }}</span>
               <h2 class="blog-title">{{ post.data.title }}</h2>
               {% if post.data.summary %}
                 <p class="blog-summary">{{ post.data.summary }}</p>

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -1,0 +1,189 @@
+/* ============================================================
+   blog.css — Roof Rite Blog grid styles
+   ============================================================ */
+
+/* ---------- Hero ---------- */
+.blog-hero {
+  text-align: center;
+  padding: 60px 5vw 30px;
+  background: #f9f9f9;
+  border-bottom: 1px solid #e8e8e8;
+}
+
+.blog-hero h1 {
+  font-family: 'Oswald', sans-serif;
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  color: #232E5E;
+  margin: 0 0 10px;
+  letter-spacing: 1px;
+}
+
+.blog-subtitle {
+  font-family: 'Work Sans', sans-serif;
+  font-size: 1.1rem;
+  color: #555;
+  margin: 0;
+}
+
+/* ---------- Search ---------- */
+.blog-search-wrap {
+  display: flex;
+  justify-content: center;
+  padding: 30px 5vw 10px;
+}
+
+.blog-search-box {
+  display: flex;
+  align-items: center;
+  border: 1px solid #ccc;
+  border-radius: 30px;
+  padding: 10px 20px;
+  width: 100%;
+  max-width: 520px;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+}
+
+.blog-search-icon {
+  font-size: 1rem;
+  margin-right: 10px;
+  color: #888;
+}
+
+.blog-search-box input {
+  border: none;
+  outline: none;
+  font-family: 'Work Sans', sans-serif;
+  font-size: 1rem;
+  width: 100%;
+  padding: 0;
+  background: transparent;
+}
+
+/* ---------- Category filter pills ---------- */
+.blog-filters {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  padding: 20px 5vw 30px;
+}
+
+.filter-btn {
+  font-family: 'Work Sans', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  padding: 8px 18px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #fff;
+  color: #444;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.filter-btn:hover {
+  background: #f0f0f0;
+  border-color: #999;
+}
+
+.filter-btn.active {
+  background: #232E5E;
+  color: #fff;
+  border-color: #232E5E;
+}
+
+/* ---------- 3-column grid ---------- */
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 28px;
+  padding: 0 5vw 80px;
+}
+
+@media (max-width: 900px) {
+  .blog-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 580px) {
+  .blog-grid { grid-template-columns: 1fr; }
+}
+
+/* ---------- Card ---------- */
+.blog-card {
+  background: #fff;
+  border: 1px solid #e8e8e8;
+  border-radius: 4px;
+  overflow: hidden;
+  transition: box-shadow 0.2s, transform 0.2s;
+}
+
+.blog-card:hover {
+  box-shadow: 0 4px 18px rgba(0,0,0,0.11);
+  transform: translateY(-2px);
+}
+
+.blog-card > a {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.blog-card img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  display: block;
+  background: #ddd;
+}
+
+.blog-card-no-img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: linear-gradient(135deg, #22305F 0%, #4A7DBC 100%);
+}
+
+.blog-card-body {
+  padding: 16px 18px 22px;
+}
+
+.blog-date {
+  display: block;
+  font-family: 'Work Sans', sans-serif;
+  font-size: 0.75rem;
+  color: #999;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.blog-title {
+  font-family: 'Work Sans', sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1a1a1a;
+  line-height: 1.4;
+  margin: 0 0 8px;
+}
+
+.blog-card:hover .blog-title {
+  color: #232E5E;
+}
+
+.blog-summary {
+  font-family: 'Work Sans', sans-serif;
+  font-size: 0.85rem;
+  color: #666;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ---------- No results ---------- */
+.blog-no-results {
+  text-align: center;
+  color: #888;
+  font-family: 'Work Sans', sans-serif;
+  font-size: 1rem;
+  padding: 40px 0 80px;
+}

--- a/blog/Ground-Level-Detective.md
+++ b/blog/Ground-Level-Detective.md
@@ -1,3 +1,13 @@
+---
+layout: page.njk
+title: "The Ground-Level Detective: How to Spot Storm Damage Without a Ladder"
+hero_image: "/assets/img/DJI_0165.jpg"
+hero_alt: "Aerial view of a Nebraska residential roof after a hail storm."
+tags: blogpost
+category: insurance
+display_date: "March 15, 2026"
+summary: "You don't need to climb a ladder to know if that storm left a mark. Here's the 3-item checklist that could save you thousands."
+---
 # The Ground-Level Detective: How to Spot Storm Damage Without a Ladder
 
 While it’s the big, flashy storms with their rolling thunderheads and golf-ball-sized hailstones that make the evening news, it’s often the repetitive, smaller showers that do the most insidious damage to a Nebraska home.

--- a/blog/Residential-Roof-2026.md
+++ b/blog/Residential-Roof-2026.md
@@ -1,4 +1,14 @@
-# The 2026 Homeowner’s Guide to Roofing & Exteriors in the Central Plains
+---
+layout: page.njk
+title: "The 2026 Homeowner's Guide to Roofing & Exteriors in the Central Plains"
+hero_image: "/assets/img/DJI_0175.jpg"
+hero_alt: "Aerial view of a residential neighborhood in Nebraska showing rooftops."
+tags: blogpost
+category: residential
+display_date: "February 1, 2026"
+summary: "Everything a Nebraska homeowner needs to know about roofing materials, spotting damage, insurance claims, and what to expect from the Roof Rite process."
+---
+# The 2026 Homeowner's Guide to Roofing & Exteriors in the Central Plains
 ## Table of Contents
 * [1. Understanding Roofing Materials](#understanding-roofing-materials-what-is-my-roof-actually-made-of)
   * [Quick Quiz: Narrowing Down Your Options](#quick-quiz-narrowing-down-your-options)
@@ -9,39 +19,39 @@
 * [6. Next Steps & Free Consultation](#next-steps)
 
 ---
-If you don’t like the weather in Nebraska, wait five minutes. For those of us with the good fortune to call this state home, we know that statement is incredibly true, for better or for worse.
+If you don't like the weather in Nebraska, wait five minutes. For those of us with the good fortune to call this state home, we know that statement is incredibly true, for better or for worse.
 
-From its flash floods in Spring and Summer to the blizzards and shocking cold of its Winter, Nebraska and its changing atmospheric conditions mean we have to stay on our toes all year round. The job is no smaller for our roofing systems. The severity of our weather means that maintaining the exterior of your property, especially your roofing system, is about much more than curb appeal. It’s a vital step in ensuring your home’s structural integrity, long-term comfort, and overall value.
+From its flash floods in Spring and Summer to the blizzards and shocking cold of its Winter, Nebraska and its changing atmospheric conditions mean we have to stay on our toes all year round. The job is no smaller for our roofing systems. The severity of our weather means that maintaining the exterior of your property, especially your roofing system, is about much more than curb appeal. It's a vital step in ensuring your home's structural integrity, long-term comfort, and overall value.
 
-At **Roof Rite Exteriors**, we understand the importance of exteriors and roofing systems that both look great and stand up to that infamous Nebraska weather. We founded our roofing company in Lincoln over a decade ago, and we’ve earned robust experience repairing and restoring our neighbors’ residential and commercial exteriors to pristine shape, all across Southeast Nebraska and the surrounding regions. 
+At **Roof Rite Exteriors**, we understand the importance of exteriors and roofing systems that both look great and stand up to that infamous Nebraska weather. We founded our roofing company in Lincoln over a decade ago, and we've earned robust experience repairing and restoring our neighbors' residential and commercial exteriors to pristine shape, all across Southeast Nebraska and the surrounding regions.
 
-From commercial flat roof repairs to industrial buildings to James Hardie siding installations on homes in Omaha, and rural barn roof replacements in Otoe County to professional exterior maintenance plans for multi-family dwellings across our growing service area, we know this land and what it takes to keep your spaces safe, secure, and stylish—no matter the weather outside.
+From commercial flat roof repairs to industrial buildings to James Hardie siding installations on homes in Omaha, and rural barn roof replacements in Otoe County to professional exterior maintenance plans for multi-family dwellings across our growing service area, we know this land and what it takes to keep your spaces safe, secure, and stylish-no matter the weather outside.
 
 ---
 
 ## Understanding Roofing Materials: What is My Roof Actually Made Of?
 
-Your roof is your home's primary defense against Nebraska's extreme weather, and the materials you choose for your roofing system also factor into your home’s long-term value and curb appeal. Choosing the right roof is a significant investment decision. 
+Your roof is your home's primary defense against Nebraska's extreme weather, and the materials you choose for your roofing system also factor into your home's long-term value and curb appeal. Choosing the right roof is a significant investment decision.
 
-In this guide, we’ll detail the perks and problems you may encounter with common roofing materials as well as roof lifespans, future maintenance, and the effect of a new roof system on your home insurance. This information is designed to help you make a confident, informed decision that is right for your property.
+In this guide, we'll detail the perks and problems you may encounter with common roofing materials as well as roof lifespans, future maintenance, and the effect of a new roof system on your home insurance. This information is designed to help you make a confident, informed decision that is right for your property.
 
 > **Note:** Nebraska's harsh weather makes it vital to choose brands known for durability and specialized technology.
 
 On commercial and residential roofs that are sloped (not flat), you may notice the following materials:
 
-*   **Asphalt Shingles:** Classic asphalt shingles are an effective and affordable way of protecting your property. Their easy installation and reliability have made them one of the most trusted roofing materials worldwide. At Roof Rite Exteriors, we’re proud to offer Class 4 Impact-Resistant and Algae-Resistant shingles in both budget-friendly architectural and premium designer styles. Your new asphalt shingles will allow you to take control of the appearance and security of your new roof.
-*   **Cedar Shakes and Shingles:** Cedar shakes and shingles have been used as an effective roofing solution for centuries—their track record speaks for itself. Classic cedar shakes are perfect for historic homes or standout custom builds. Their color becomes a sharp silver with the passing of time. Wood Shakes have a low impact on the environment, and they perform exceptionally well against hail. At Roof Rite, every cedar roof we install is carefully crafted for proper spacing, ventilation, and water shedding to ensure your roof’s maximum longevity.
-*   **Composite Roofing:** Composite roofs provide premium aesthetic appearances that mimic natural wood or stone—without the costly upkeep and maintenance of an organic roofing system.
-    *   Our composite roofs outperform slate and cedar shake against fire, hail, and wind. They provide exceptional protection against Mother Nature’s most severe weather.
-    *   Because composite roofs are inorganic, they’re impervious to damaging roaches, termites, and other pests.
-    *   From slate to shake to tile, composite options replicate authentic textures and tones with incredible detail and consistency. They’re sought after by HOA boards and historic commissions, because they don’t have the weight and fragility of traditional natural stone or wood.
-    *   Boasting a whopping 50+ year lifespan that’s as long as that of metal roofing, composite roofs have the added advantage of being non-corrosive and dent-proof. Their Class 4 Impact Rating and 110+ mph wind resistance make them the strongest contender for your sloped roof project.
-*   **Metal Roofing:** Metal roofs offer superb protection against wind, hail, and fire. Their rustproof coatings resist corrosion and cracking for more than 50 years, and their durable nature precludes them from the costly repair and maintenance of most roofs. Roof Rite’s expert installation team is experienced in building and installing complex metal systems with precision, ensuring maximum longevity and performance.
+*   **Asphalt Shingles:** Classic asphalt shingles are an effective and affordable way of protecting your property. Their easy installation and reliability have made them one of the most trusted roofing materials worldwide. At Roof Rite Exteriors, we're proud to offer Class 4 Impact-Resistant and Algae-Resistant shingles in both budget-friendly architectural and premium designer styles. Your new asphalt shingles will allow you to take control of the appearance and security of your new roof.
+*   **Cedar Shakes and Shingles:** Cedar shakes and shingles have been used as an effective roofing solution for centuries-their track record speaks for itself. Classic cedar shakes are perfect for historic homes or standout custom builds. Their color becomes a sharp silver with the passing of time. Wood Shakes have a low impact on the environment, and they perform exceptionally well against hail. At Roof Rite, every cedar roof we install is carefully crafted for proper spacing, ventilation, and water shedding to ensure your roof's maximum longevity.
+*   **Composite Roofing:** Composite roofs provide premium aesthetic appearances that mimic natural wood or stone-without the costly upkeep and maintenance of an organic roofing system.
+    *   Our composite roofs outperform slate and cedar shake against fire, hail, and wind. They provide exceptional protection against Mother Nature's most severe weather.
+    *   Because composite roofs are inorganic, they're impervious to damaging roaches, termites, and other pests.
+    *   From slate to shake to tile, composite options replicate authentic textures and tones with incredible detail and consistency. They're sought after by HOA boards and historic commissions, because they don't have the weight and fragility of traditional natural stone or wood.
+    *   Boasting a whopping 50+ year lifespan that's as long as that of metal roofing, composite roofs have the added advantage of being non-corrosive and dent-proof. Their Class 4 Impact Rating and 110+ mph wind resistance make them the strongest contender for your sloped roof project.
+*   **Metal Roofing:** Metal roofs offer superb protection against wind, hail, and fire. Their rustproof coatings resist corrosion and cracking for more than 50 years, and their durable nature precludes them from the costly repair and maintenance of most roofs. Roof Rite's expert installation team is experienced in building and installing complex metal systems with precision, ensuring maximum longevity and performance.
 
 Check out our detailed comparison of [Asphalt vs Composite Roofing HERE]([INSERT LINK HERE]).
 
 ### Quick Quiz: Narrowing Down Your Options
-If you’re unsure about what type of roofing materials are right for your home, use this handy two-part quiz to help narrow down your options:
+If you're unsure about what type of roofing materials are right for your home, use this handy two-part quiz to help narrow down your options:
 1. What is my 10-year plan for this property?
 2. What kind of climate do I live in, and what are its extreme conditions like?
 
@@ -51,13 +61,13 @@ Depending on how you answer these questions, your roof decision may become clear
 
 ## How to Spot Roof Damage Early
 
-Don’t wait for the dreaded ceiling drip in your living spaces—catching roof damage early may save you thousands of dollars in extensive repairs.
- 
+Don't wait for the dreaded ceiling drip in your living spaces-catching roof damage early may save you thousands of dollars in extensive repairs.
+
 Here are 5 common signs that your roof needs professional attention:
 
-1.  **Excessive Granule Loss:** Asphalt shingles are coated in small, sand-like granules that protect the underlying asphalt from harmful UV rays. If you notice a buildup of what looks like coarse sand in your gutters or at the base of your downspouts, it’s a sign that your shingles are deteriorating or have been impacted by hail. Loss of granules dramatically reduces your roof's lifespan, because without UV protection, the polymers used to create modern shingles can “bake” in the sun, leading to cracks and the eventual intrusion of moisture on interior surfaces—a sure sign of roof failure.
+1.  **Excessive Granule Loss:** Asphalt shingles are coated in small, sand-like granules that protect the underlying asphalt from harmful UV rays. If you notice a buildup of what looks like coarse sand in your gutters or at the base of your downspouts, it's a sign that your shingles are deteriorating or have been impacted by hail. Loss of granules dramatically reduces your roof's lifespan, because without UV protection, the polymers used to create modern shingles can "bake" in the sun, leading to cracks and the eventual intrusion of moisture on interior surfaces-a sure sign of roof failure.
 2.  **Missing, Curled, or Cracked Shingles:** Wind damage often starts with barely visible signs, so we closely inspect your roof for shingles that are lifted, creased, or completely missing. Curling or buckling shingles are often indicators of age or of poor attic ventilation, and require immediate attention.
-3.  **Broken or Compromised Flashing:** Flashing is the metal or membrane that seals areas around roof penetrations, such as chimneys, vents, skylights, and HVAC units. It’s the part of the roofing structure that looks a little like metal stairsteps or zig-zags surrounding these fixtures. Cracks, gaps, or separation in these areas are high-risk entry points for water, especially in climates characterized by frequent freeze-thaw cycles, which we know all too well as a hallmark of the colder months in Nebraska.
+3.  **Broken or Compromised Flashing:** Flashing is the metal or membrane that seals areas around roof penetrations, such as chimneys, vents, skylights, and HVAC units. It's the part of the roofing structure that looks a little like metal stairsteps or zig-zags surrounding these fixtures. Cracks, gaps, or separation in these areas are high-risk entry points for water, especially in climates characterized by frequent freeze-thaw cycles, which we know all too well as a hallmark of the colder months in Nebraska.
 4.  **Interior Water Damage or Odors:** Water damage doesn't always show up as a huge puddle on the floor. Check your ceilings and walls for spots of yellowing or dark discoloration and staining. A persistent musty or earthy smell is also a strong clue, often indicating hidden mold or moisture buildup within the wall or ceiling cavities.
 5.  **Sagging or Uneven Roof Plane:** A visible dip or curvature in your roofline can signal a serious structural problem, potentially involving damage to the roof decking or underlying supports. This requires immediate inspection in order to prevent further damage.
 
@@ -69,10 +79,10 @@ Check out our [Ground-Level Detective Checklist HERE]([INSERT LINK HERE]).
 
 Replacing your roof is a significant project, which is why we provide a **"No-Surprises" roadmap** to ensure a streamlined, professional experience from start to finish.
 
-*   **Step 1: Comprehensive Inspection:** We meticulously assess your entire roofing system, including your roof decking, underlayment, ventilation, and flashing, and document every finding with detailed notes and high-resolution photos for your (and your insurance carrier’s) records.
+*   **Step 1: Comprehensive Inspection:** We meticulously assess your entire roofing system, including your roof decking, underlayment, ventilation, and flashing, and document every finding with detailed notes and high-resolution photos for your (and your insurance carrier's) records.
 *   **Step 2: Detailed, Transparent Estimate:** We provide a transparent, line-item estimate, fully explaining the materials and scope of work to ensure there are no hidden fees or unexpected costs.
 *   **Step 3: Professional Tear-off & Installation:** Our experienced crews treat your property with the utmost respect. We implement specialized protection for your landscaping and siding before the tear-off even begins. Your new roofing system is then installed to exact manufacturer specifications, ensuring long-term durability and full warranty compliance.
-*   **Step 4: The Final Walkthrough & Cleanup:** We aren't finished until the jobsite is pristine. Our teams are respectful of where you live and work. You won’t need to worry about damaged property or landscaping; we also conduct multiple magnetic sweeps to ensure your lawn and driveway are clear of debris. Finally, we perform a joint walkthrough to review the completed work, answer any final questions, and ensure you are 100% satisfied with the results.
+*   **Step 4: The Final Walkthrough & Cleanup:** We aren't finished until the jobsite is pristine. Our teams are respectful of where you live and work. You won't need to worry about damaged property or landscaping; we also conduct multiple magnetic sweeps to ensure your lawn and driveway are clear of debris. Finally, we perform a joint walkthrough to review the completed work, answer any final questions, and ensure you are 100% satisfied with the results.
 
 ---
 
@@ -82,9 +92,9 @@ At Roof Rite Exteriors, we understand that navigating an insurance claim for hai
 
 Count on Roof Rite to serve as your professional advocate. We provide the precise documentation and long-term roofing/exteriors expertise that are required to navigate your claim process successfully.
 
-Our team of professional estimators and production crews can “speak the language” of insurance adjusters, which is one of our critical advantages. Identifying damage is only part of the puzzle—the rest is successfully navigating the rigorous insurance timeline. 
+Our team of professional estimators and production crews can "speak the language" of insurance adjusters, which is one of our critical advantages. Identifying damage is only part of the puzzle-the rest is successfully navigating the rigorous insurance timeline.
 
-Most standard homeowner insurance contracts follow a **One-Year Rule**, requiring claims to be filed within 365 days of the actual storm date. Waiting until you see a visible leak—which might not appear until 14+ months later—can result in a denied claim, meaning the homeowner is out of luck and has to shoulder the full financial burden for repairs.
+Most standard homeowner insurance contracts follow a **One-Year Rule**, requiring claims to be filed within 365 days of the actual storm date. Waiting until you see a visible leak-which might not appear until 14+ months later-can result in a denied claim, meaning the homeowner is out of luck and has to shoulder the full financial burden for repairs.
 
 To protect your investment, at Roof Rite Exteriors we provide proactive, professional roof inspections that offer several key advantages:
 *   **Time-Stamped Proof:** We document evidence immediately following a storm, tying specific damage directly to the weather event.
@@ -97,18 +107,18 @@ Don't wait for a drip in your living room to take action. Early detection and ex
 
 ## Interior Protection
 
-When storm damage breaches your roof's outer layer, the consequences are immediate and often hidden, affecting the interior of your home long before a visible drip appears. 
+When storm damage breaches your roof's outer layer, the consequences are immediate and often hidden, affecting the interior of your home long before a visible drip appears.
 
-Roof leaks frequently lead to attic moisture, damaged insulation, and significant drywall deterioration. Water that penetrates the attic space creates an ideal environment for mold and mildew growth, which poses a severe health risk and compromises the structural integrity of your home. If you’re already seeing yellow, brown, or dark spots on your ceiling or walls, it indicates that water has been pooling or running for some time—and the damage is, unfortunately, well past the initial phase. Ignoring these signs can lead to costly structural repairs and devaluation of your property.
+Roof leaks frequently lead to attic moisture, damaged insulation, and significant drywall deterioration. Water that penetrates the attic space creates an ideal environment for mold and mildew growth, which poses a severe health risk and compromises the structural integrity of your home. If you're already seeing yellow, brown, or dark spots on your ceiling or walls, it indicates that water has been pooling or running for some time-and the damage is, unfortunately, well past the initial phase. Ignoring these signs can lead to costly structural repairs and devaluation of your property.
 
-To tackle these urgent internal restoration needs, we partner with our dedicated division, **Service Rite**. While Roof Rite focuses on the integrity of your home’s exterior, we understand that water infiltrating your interior spaces demands swift and specialized attention. Count on the Service Rite experts in disaster recovery. From water mitigation due to a compromised exterior, like broken flashing or detached fascia, to complete restorations after fires and smoke damage, Service Rite is your trusted partner in full-scale interior rehabilitation.
+To tackle these urgent internal restoration needs, we partner with our dedicated division, **Service Rite**. While Roof Rite focuses on the integrity of your home's exterior, we understand that water infiltrating your interior spaces demands swift and specialized attention. Count on the Service Rite experts in disaster recovery. From water mitigation due to a compromised exterior, like broken flashing or detached fascia, to complete restorations after fires and smoke damage, Service Rite is your trusted partner in full-scale interior rehabilitation.
 
-Visit our [Service Rite Restoration Hub]([INSERT LINK HERE]) to explore how professional mitigation can safeguard your home’s interior. Taking fast action on moisture issues not only keeps repair costs down but also prevents long-term health risks like mold growth and structural failure.
+Visit our [Service Rite Restoration Hub]([INSERT LINK HERE]) to explore how professional mitigation can safeguard your home's interior. Taking fast action on moisture issues not only keeps repair costs down but also prevents long-term health risks like mold growth and structural failure.
 
 ---
 
 ## Next Steps
 
-Don't leave your home’s safety to chance. Whether you need a minor repair or a full replacement, our friendly team of roofing experts at Roof Rite Exteriors is ready to help. 
+Don't leave your home's safety to chance. Whether you need a minor repair or a full replacement, our friendly team of roofing experts at Roof Rite Exteriors is ready to help.
 
 Call us at **(402) 430-9538** or [click here to contact us online]([INSERT LINK HERE]).

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,20 +1,5 @@
 ---
-layout: page.njk
-title: "Roof Rite Blog"
-hero_image: "/assets/img/Rolling-Charlie.png"
-hero_alt: "A Roof Rite team member uses a heat welder to seam white TPO roofing membrane on a flat roof at sunset. He kneels over the material with a hot-air gun in one hand and a silicone roller in the other, ensuring a secure bond."
+layout: blog-index.njk
+title: Roof Rite Blog
+description: "Expert roofing tips, updates, and insights from the Roof Rite Exteriors team in Lincoln, NE."
 ---
-
-## Our blog posts
-
-### 2026
-
-[Understanding the Insurance Claim Process for Hail & Wind Damage](understanding_insurance_wind_and_hail) &mdash; New insurance claim? Use this crash course to help navigate!
-
-### 2025
-
-[Low-Slope Roof Maintenance](low_slope_maintenance) &mdash; Why yearly inspections save you money (and headaches!)
-
-[James Hardie Siding Investment](james_hardie_siding_investment) &mdash; Why James Hardie is a smart investment for your home.
-
-

--- a/blog/james_hardie_siding_investment.md
+++ b/blog/james_hardie_siding_investment.md
@@ -1,8 +1,12 @@
 ---
 layout: page.njk
-title: "New James Hardie Siding"
+title: "Why James Hardie Siding is the Smartest Investment for Your Home"
 hero_image: "/assets/img/Siding1.jpg"
 hero_alt: "A new Board and Batten James Hardie Siding Project, installed by Roof Rite."
+tags: blogpost
+category: residential
+display_date: "September 1, 2025"
+summary: "Long-lasting protection, stunning looks, and minimal upkeep — here's why fiber cement siding is the gold standard."
 ---
 # Why James Hardie Siding is the Smartest Investment for Your Home
 

--- a/blog/low_slope_maintenance.md
+++ b/blog/low_slope_maintenance.md
@@ -1,8 +1,12 @@
 ---
 layout: page.njk
-title: "Roof Rite Blog"
+title: "Why Yearly Maintenance on Your Low-Slope Roof is Essential"
 hero_image: "/assets/img/DJI_0027.jpg"
-hero_alt: "A Roof Rite team member uses a heat welder to seam white TPO roofing membrane on a flat roof at sunset. He kneels over the material with a hot-air gun in one hand and a silicone roller in the other, ensuring a secure bond."
+hero_alt: "A Roof Rite team member uses a heat welder to seam white TPO roofing membrane on a flat roof at sunset."
+tags: blogpost
+category: commercial
+display_date: "November 1, 2025"
+summary: "Why yearly inspections on flat and low-slope roofs save you money and headaches — and exactly what to look for."
 ---
 
 # Why Yearly Maintenance on Your Low-Slope Roof is Essential  

--- a/blog/steps_for_homeowners_claim.md
+++ b/blog/steps_for_homeowners_claim.md
@@ -1,8 +1,12 @@
 ---
 layout: page.njk
-title: "Steps for homeowners claim"
+title: "Steps for Filing a Homeowners Insurance Claim"
 hero_image: "/assets/img/IMG_2553.png"
-hero_alt: "Here you should put alt text describing the image"
+hero_alt: "A Roof Rite truck parked in front of a house being inspected after storm damage."
+tags: blogpost
+category: insurance
+display_date: "April 1, 2026"
+summary: "A simple step-by-step walkthrough for filing a homeowners insurance claim after storm damage to your roof."
 ---
 
 ## This is a sample blog post

--- a/blog/understanding_insurance_wind_and_hail.md
+++ b/blog/understanding_insurance_wind_and_hail.md
@@ -3,6 +3,10 @@ layout: page.njk
 title: "Understanding the Insurance Claim Process for Hail & Wind Damage"
 hero_image: "/assets/img/IMG_2553.png"
 hero_alt: "A Roof Rite Truck parked in front of a large house with a new roof."
+tags: blogpost
+category: insurance
+display_date: "January 15, 2026"
+summary: "New insurance claim? Use this crash course to navigate the full hail and wind damage process from filing to final payment."
 ---
 # Understanding the Insurance Claim Process for Hail & Wind Damage
 


### PR DESCRIPTION
## What this does

Upgrades the blog page from a plain text list to a 3-column image card grid, matching the Casey Nelson Roofing layout.

### New files
- `_includes/blog-index.njk` — new Eleventy layout for the blog index; auto-builds cards from all posts tagged `blogpost`
- `assets/css/blog.css` — card grid styles

### Updated files
- `blog/index.md` — now uses `blog-index.njk` layout
- All 6 blog posts — added `tags: blogpost`, `category`, `display_date`, `summary`, and fixed a couple titles

### How it works going forward (for Cathy)
Any new blog post file just needs these lines in its frontmatter and it will appear on the index automatically:
```yaml
tags: blogpost
category: residential   # or: commercial / insurance / maintenance
display_date: "June 16, 2026"
summary: "One-sentence description that shows under the title on the card."
```
No manual editing of the index page required.