### PR TITLE
Add blog section with search and filter functionality

### DIFF
--- a/_includes/main.njk
+++ b/_includes/main.njk
@@ -38,6 +38,54 @@ description: "The trusted source for all your exterior needs"
       <figure class="rightfig">
         <img src="/assets/img/IMG_4238.png" alt="High angle view of a Roof Rite team member fabricating a sheet of copper using a metal brake in the workshop. The technician is aligning the material for precise bends, wearing a Roof Rite shirt with the company logo and phone number visible."/>
       </figure>
+<main>
+  <div class="blog-page-wrapper">
+
+    <div class="blog-hero">
+      <h1>Blog</h1>
+      <p class="blog-subtitle">Tips, updates &amp; insights from the Roof Rite team</p>
+    </div>
+
+    <div class="blog-search-wrap">
+      <div class="blog-search-box">
+        <span class="blog-search-icon">&#128269;</span>
+        <input type="text" id="blog-search" placeholder="Search articles…" oninput="filterBlog()">
+      </div>
+    </div>
+
+    <div class="blog-filters">
+      <button class="filter-btn active" onclick="setFilter('all', this)">ALL POSTS</button>
+      <button class="filter-btn" onclick="setFilter('residential', this)">RESIDENTIAL</button>
+      <button class="filter-btn" onclick="setFilter('commercial', this)">COMMERCIAL</button>
+      <button class="filter-btn" onclick="setFilter('insurance', this)">INSURANCE</button>
+      <button class="filter-btn" onclick="setFilter('maintenance', this)">MAINTENANCE</button>
+    </div>
+
+    <div class="blog-grid" id="blog-grid">
+      {% for post in collections.blogpost | reverse %}
+      <article class="blog-card" data-category="{{ post.data.category | default('general') }}" data-title="{{ post.data.title | lower }}">
+        <a href="{{ post.url }}">
+          {% if post.data.hero_image %}
+            <img src="{{ post.data.hero_image }}" alt="{{ post.data.hero_alt | default(post.data.title) }}" loading="lazy">
+          {% else %}
+            <div class="blog-card-no-img"></div>
+          {% endif %}
+          <div class="blog-card-body">
+            <h2 class="blog-title">{{ post.data.title }}</h2>
+            {% if post.data.summary %}
+              <p class="blog-summary">{{ post.data.summary }}</p>
+            {% endif %}
+          </div>
+        </a>
+      </article>
+      {% endfor %}
+    </div>
+
+    <p class="blog-no-results" id="blog-no-results" style="display:none;">
+      No articles matched your search.
+    </p>
+
+  </div> </main>
     </main>
 
     {% include "cards.njk" %}

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -11,15 +11,28 @@
   --text-muted: #999;
 }
 
-/* ---------- NEW ISOLATION WRAPPER ---------- */
-.blog-page-wrapper {
-  display: flex !important;
-  flex-direction: column !important; /* Strictly stacks layout sections downward */
-  width: 100vw !important;           /* Forces wrapper to stretch edge-to-edge */
-  max-width: 100% !important;        /* Neutralizes main.css width caps */
-  margin: 0 auto !important;
+/* ---------- THE ULTIMATE ISOLATION RESET ---------- */
+main .blog-page-wrapper {
+  display: block !important;         /* Changes layout context from flex to standard block */
+  clear: both !important;            /* Breaks any floated elements */
+  float: none !important;            /* Cancels any floating */
+  width: 100% !important;            /* Takes up full width */
+  max-width: 100vw !important;       /* Explicitly overrides any max-width limits */
+  margin: 0 auto !important;         /* Centers the block container */
   padding: 0 !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
+}
+
+/* Force every direct child of the wrapper to strictly be a block item that stacks */
+main .blog-page-wrapper > div,
+main .blog-page-wrapper > header,
+main .blog-page-wrapper > p {
+  display: block !important;
+  width: 100% !important;
+  clear: both !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  box-sizing: border-box !important;
 }
 
 /* ---------- Hero banner ---------- */


### PR DESCRIPTION
Bypasses global main.css flex/width rules by encapsulating the blog view inside .blog-page-wrapper. Corrects desktop layout where cards and filters were pushed sideways instead of stacking vertically.